### PR TITLE
Add VPC Lattice as an upstream source for lambda-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This package makes it easy to run AWS Lambda Functions written in Rust. This workspace includes multiple crates:
 
 - [![Docs](https://docs.rs/lambda_runtime/badge.svg)](https://docs.rs/lambda_runtime) **`lambda-runtime`** is a library that provides a Lambda runtime for applications written in Rust.
-- [![Docs](https://docs.rs/lambda_http/badge.svg)](https://docs.rs/lambda_http) **`lambda-http`** is a library that makes it easy to write API Gateway proxy event focused Lambda functions in Rust.
+- [![Docs](https://docs.rs/lambda_http/badge.svg)](https://docs.rs/lambda_http) **`lambda-http`** is a library for writing HTTP Lambda functions in Rust, with support for upstream API Gateway, ALB, Lambda Function URLs, and VPC Lattice.
 - [![Docs](https://docs.rs/lambda-extension/badge.svg)](https://docs.rs/lambda-extension) **`lambda-extension`** is a library that makes it easy to write Lambda Runtime Extensions in Rust.
 - [![Docs](https://docs.rs/aws_lambda_events/badge.svg)](https://docs.rs/aws_lambda_events) **`lambda-events`** is a library with strongly-typed Lambda event structs in Rust.
 - [![Docs](https://docs.rs/lambda_runtime_api_client/badge.svg)](https://docs.rs/lambda_runtime_api_client) **`lambda-runtime-api-client`** is a shared library between the lambda runtime and lambda extension libraries that includes a common API client to talk with the AWS Lambda Runtime API.

--- a/lambda-events/src/event/vpc_lattice/v2.rs
+++ b/lambda-events/src/event/vpc_lattice/v2.rs
@@ -1,7 +1,4 @@
-use crate::{
-    custom_serde::{deserialize_headers, deserialize_nullish, http_method, serialize_multi_value_headers},
-    encodings::Body,
-};
+use crate::custom_serde::{deserialize_headers, deserialize_nullish, http_method, serialize_multi_value_headers};
 #[cfg(feature = "builders")]
 use bon::Builder;
 use http::{HeaderMap, Method};
@@ -47,7 +44,7 @@ pub struct VpcLatticeRequestV2 {
 
     /// The request body
     #[serde(default)]
-    pub body: Option<Body>,
+    pub body: Option<String>,
 
     /// Whether the body is base64 encoded
     #[serde(default, deserialize_with = "deserialize_nullish")]

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -17,11 +17,12 @@ categories = ["web-programming::http-server"]
 readme = "README.md"
 
 [features]
-default = ["apigw_rest", "apigw_http", "apigw_websockets", "alb", "tracing"]
+default = ["apigw_rest", "apigw_http", "apigw_websockets", "alb", "vpc_lattice", "tracing"]
 apigw_rest = []
 apigw_http = []
 apigw_websockets = []
 alb = []
+vpc_lattice = []
 pass_through = []
 catch-all-fields = ["aws_lambda_events/catch-all-fields"]
 tracing = ["lambda_runtime/tracing"] # enables access to the Tracing utilities
@@ -53,7 +54,7 @@ url = "2.2"
 path = "../lambda-events"
 version = "1.1"
 default-features = false
-features = ["alb", "apigw"]
+features = ["alb", "apigw", "vpc_lattice"]
 
 [dev-dependencies]
 axum-core = "0.5.4"

--- a/lambda-http/README.md
+++ b/lambda-http/README.md
@@ -2,7 +2,9 @@
 
 [![Docs](https://docs.rs/lambda_http/badge.svg)](https://docs.rs/lambda_http)
 
-**`lambda-http`** is an abstraction that takes payloads from different services and turns them into http objects, making it easy to write API Gateway proxy event focused Lambda functions in Rust.
+**`lambda-http`** is an abstraction that takes HTTP-shaped payloads from different AWS services and turns them
+into standard `http` objects, making it easy to write Lambda functions in Rust that serve HTTP traffic
+regardless of the upstream trigger.
 
 lambda-http handler is made of:
 
@@ -14,17 +16,18 @@ We are able to handle requests from:
 * [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html) REST, HTTP and WebSockets API lambda integrations
 * AWS [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html)
 * AWS [Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html)
+* AWS [VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html)
 
-Thanks to the `Request` type we can seamlessly handle proxy integrations without the worry to specify the specific service type.
+Thanks to the `Request` type we can seamlessly handle all of these triggers without having to write service-specific code.
 
-There is also an extension for `lambda_http::Request` structs that provides access to [API gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) and [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html) features.
+There is also an extension for `lambda_http::Request` structs that provides access to [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format), [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html), and [VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html) features.
 
 For example some handy extensions:
 
 * `query_string_parameters` - Return pre-parsed http query string parameters, parameters provided after the `?` portion of a url associated with the request
 * `path_parameters` - Return pre-extracted path parameters, parameter provided in url placeholders `/foo/{bar}/baz/{qux}` associated with the request
 * `lambda_context` - Return the Lambda context for the invocation; see the [runtime docs](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next)
-* `request_context` - Return the ALB/API Gateway request context
+* `request_context` - Return the ALB, API Gateway, or VPC Lattice request context
 * payload - Return the Result of a payload parsed into a type that implements `serde::Deserialize`
 
 See the `lambda_http::RequestPayloadExt` and `lambda_http::RequestExt` traits for more extensions.
@@ -238,16 +241,17 @@ If you don't want to receive the stage as part of the path, you can set the envi
 
 ## Feature flags
 
-`lambda_http` is a wrapper for HTTP events coming from three different services, Amazon Load Balancer (ALB), Amazon Api Gateway (APIGW), and AWS Lambda Function URLs. Amazon Api Gateway can also send events from three different endpoints, REST APIs, HTTP APIs, and WebSockets. `lambda_http` transforms events from all these sources into native `http::Request` objects, so you can incorporate Rust HTTP semantics into your Lambda functions.
+`lambda_http` is a wrapper for HTTP events coming from four different AWS services: Application Load Balancer (ALB), API Gateway, Lambda Function URLs, and VPC Lattice. API Gateway can send events from three different endpoint types: REST APIs, HTTP APIs, and WebSockets. `lambda_http` transforms events from all these sources into native `http::Request` objects, so you can incorporate Rust HTTP semantics into your Lambda functions.
 
 By default, `lambda_http` compiles your function to support any of those services. This increases the compile time of your function because we have to generate code for all the sources. In reality, you'll usually put a Lambda function only behind one of those sources. You can choose which source to generate code for with feature flags.
 
-The available features flags for `lambda_http` are the following:
+The available feature flags for `lambda_http` are the following:
 
 - `alb`: for events coming from [Amazon Elastic Load Balancer](https://aws.amazon.com/elasticloadbalancing/).
-- `apigw_rest`: for events coming from [Amazon API Gateway Rest APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html).
+- `apigw_rest`: for events coming from [Amazon API Gateway REST APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html).
 - `apigw_http`: for events coming from [Amazon API Gateway HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) and [AWS Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html).
 - `apigw_websockets`: for events coming from [Amazon API Gateway WebSockets](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
+- `vpc_lattice`: for events coming from [AWS VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html).
 
 If you only want to support one of these sources, you can disable the default features, and enable only the source that you care about in your package's `Cargo.toml` file. Substitute the dependency line for `lambda_http` for the snippet below, changing the feature that you want to enable:
 

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -7,6 +7,9 @@ use aws_lambda_events::apigw::ApiGatewayProxyRequest;
 use aws_lambda_events::apigw::ApiGatewayV2httpRequest;
 #[cfg(feature = "apigw_websockets")]
 use aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest;
+#[cfg(feature = "vpc_lattice")]
+use aws_lambda_events::vpc_lattice::VpcLatticeRequestV2;
+
 use serde::{de::Error, Deserialize};
 use serde_json::value::RawValue;
 
@@ -38,6 +41,10 @@ impl<'de> Deserialize<'de> for LambdaRequest {
         #[cfg(feature = "apigw_websockets")]
         if let Ok(res) = serde_json::from_str::<ApiGatewayWebsocketProxyRequest>(data) {
             return Ok(LambdaRequest::WebSocket(res));
+        }
+        #[cfg(feature = "vpc_lattice")]
+        if let Ok(res) = serde_json::from_str::<VpcLatticeRequestV2>(data) {
+            return Ok(LambdaRequest::VpcLatticeV2(res));
         }
         #[cfg(feature = "pass_through")]
         if PASS_THROUGH_ENABLED {
@@ -131,6 +138,20 @@ mod tests {
         match req {
             LambdaRequest::WebSocket(req) => {
                 assert_eq!("CONNECT", req.request_context.event_type.unwrap());
+            }
+            other => panic!("unexpected request variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_vpc_lattice() {
+        let data =
+            include_bytes!("../../lambda-events/src/fixtures/example-vpc-lattice-v2-request.json");
+
+        let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize vpc lattice data");
+        match req {
+            LambdaRequest::VpcLatticeV2(req) => {
+                assert_eq!("arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09", req.request_context.target_group_arn);
             }
             other => panic!("unexpected request variant: {other:?}"),
         }

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -145,13 +145,15 @@ mod tests {
 
     #[test]
     fn test_deserialize_vpc_lattice() {
-        let data =
-            include_bytes!("../../lambda-events/src/fixtures/example-vpc-lattice-v2-request.json");
+        let data = include_bytes!("../../lambda-events/src/fixtures/example-vpc-lattice-v2-request.json");
 
         let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize vpc lattice data");
         match req {
             LambdaRequest::VpcLatticeV2(req) => {
-                assert_eq!("arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09", req.request_context.target_group_arn);
+                assert_eq!(
+                    "arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09",
+                    req.request_context.target_group_arn
+                );
             }
             other => panic!("unexpected request variant: {other:?}"),
         }

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -2,7 +2,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //#![deny(warnings)]
 //! Enriches the `lambda` crate with [`http`](https://github.com/hyperium/http)
-//! types targeting AWS [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html), [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html) REST and HTTP API lambda integrations.
+//! types targeting AWS
+//! [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html),
+//! [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html),
+//! [VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html) REST and HTTP API lambda integrations.
 //!
 //! This crate abstracts over all of these trigger events using standard [`http`](https://github.com/hyperium/http) types minimizing the mental overhead
 //! of understanding the nuances and variation between trigger details allowing you to focus more on your application while also giving you to the maximum flexibility to

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -3,9 +3,9 @@
 //#![deny(warnings)]
 //! Enriches the `lambda` crate with [`http`](https://github.com/hyperium/http)
 //! types targeting AWS
-//! [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html),
-//! [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html),
-//! [VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html) REST and HTTP API lambda integrations.
+//! * [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html)
+//! * [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html) REST and HTTP API lambda integrations
+//! * [VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html)
 //!
 //! This crate abstracts over all of these trigger events using standard [`http`](https://github.com/hyperium/http) types minimizing the mental overhead
 //! of understanding the nuances and variation between trigger details allowing you to focus more on your application while also giving you to the maximum flexibility to

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -1,6 +1,6 @@
-//! ALB and API Gateway request adaptations
+//! ALB and API Gateway and VPC Lattice request adaptations
 //!
-//! Typically these are exposed via the [`request_context()`] or [`request_context_ref()`]
+//! Typically, these are exposed via the [`request_context()`] or [`request_context_ref()`]
 //! request extension methods provided by the [`RequestExt`] trait.
 //!
 //! [`request_context()`]: crate::RequestExt::request_context()
@@ -12,7 +12,8 @@ use crate::ext::extensions::{PathParameters, StageVariables};
     feature = "apigw_rest",
     feature = "apigw_http",
     feature = "alb",
-    feature = "apigw_websockets"
+    feature = "apigw_websockets",
+    feature = "vpc_lattice"
 ))]
 use crate::ext::extensions::{QueryStringParameters, RawHttpPath};
 #[cfg(feature = "alb")]
@@ -25,6 +26,9 @@ use aws_lambda_events::apigw::{ApiGatewayProxyRequest, ApiGatewayProxyRequestCon
 use aws_lambda_events::apigw::{ApiGatewayV2httpRequest, ApiGatewayV2httpRequestContext};
 #[cfg(feature = "apigw_websockets")]
 use aws_lambda_events::apigw::{ApiGatewayWebsocketProxyRequest, ApiGatewayWebsocketProxyRequestContext};
+#[cfg(feature = "vpc_lattice")]
+use aws_lambda_events::vpc_lattice::{VpcLatticeRequestV2, VpcLatticeRequestV2Context};
+
 use aws_lambda_events::{encodings::Body, query_map::QueryMap};
 use http::{header::HeaderName, HeaderMap, HeaderValue};
 
@@ -35,7 +39,7 @@ use std::{env, future::Future, io::Read, pin::Pin};
 use url::Url;
 
 /// Internal representation of an Lambda http event from
-/// ALB, API Gateway REST and HTTP API proxy event perspectives
+/// ALB, VPC Lattice Lambda, API Gateway REST and HTTP API proxy event perspectives
 ///
 /// This is not intended to be a type consumed by crate users directly. The order
 /// of the variants are notable. Serde will try to deserialize in this order.
@@ -51,6 +55,8 @@ pub enum LambdaRequest {
     Alb(AlbTargetGroupRequest),
     #[cfg(feature = "apigw_websockets")]
     WebSocket(ApiGatewayWebsocketProxyRequest),
+    #[cfg(feature = "vpc_lattice")]
+    VpcLatticeV2(VpcLatticeRequestV2),
     #[cfg(feature = "pass_through")]
     PassThrough(String),
 }
@@ -69,15 +75,18 @@ impl LambdaRequest {
             LambdaRequest::Alb { .. } => RequestOrigin::Alb,
             #[cfg(feature = "apigw_websockets")]
             LambdaRequest::WebSocket { .. } => RequestOrigin::WebSocket,
+            #[cfg(feature = "vpc_lattice")]
+            LambdaRequest::VpcLatticeV2 { .. } => RequestOrigin::VpcLatticeV2,
             #[cfg(feature = "pass_through")]
             LambdaRequest::PassThrough { .. } => RequestOrigin::PassThrough,
             #[cfg(not(any(
                 feature = "apigw_rest",
                 feature = "apigw_http",
                 feature = "alb",
-                feature = "apigw_websockets"
+                feature = "apigw_websockets",
+                feature = "vpc_lattice",
             )))]
-            _ => compile_error!("Either feature `apigw_rest`, `apigw_http`, `alb`, or `apigw_websockets` must be enabled for the `lambda-http` crate."),
+            _ => compile_error!("Either feature `apigw_rest`, `apigw_http`, `alb`, `apigw_websockets` or `vpc_lattice` must be enabled for the `lambda-http` crate."),
         }
     }
 }
@@ -102,6 +111,9 @@ pub enum RequestOrigin {
     /// API Gateway WebSocket
     #[cfg(feature = "apigw_websockets")]
     WebSocket,
+    /// VPC Lattice origin
+    #[cfg(feature = "vpc_lattice")]
+    VpcLatticeV2,
     /// PassThrough request origin
     #[cfg(feature = "pass_through")]
     PassThrough,
@@ -274,7 +286,7 @@ fn into_alb_request(alb: AlbTargetGroupRequest) -> http::Request<Body> {
     req
 }
 
-#[cfg(feature = "alb")]
+#[cfg(any(feature = "alb", feature = "vpc_lattice"))]
 fn decode_query_map(query_map: QueryMap) -> QueryMap {
     use std::str::FromStr;
 
@@ -337,6 +349,43 @@ fn into_websocket_request(ag: ApiGatewayWebsocketProxyRequest) -> http::Request<
     req
 }
 
+
+#[cfg(feature = "vpc_lattice")]
+fn into_vpc_lattice_request(vlr: VpcLatticeRequestV2) -> http::Request<Body> {
+    let http_method = vlr.method;
+    let host = vlr.headers.get(http::header::HOST).and_then(|s| s.to_str().ok());
+    let raw_path = vlr.path.unwrap_or_default();
+
+    let query_string_parameters = decode_query_map(vlr.query_string_parameters);
+
+    let builder = http::Request::builder()
+        .uri(build_request_uri(
+            &raw_path,
+            &vlr.headers,
+            host,
+            Some((&query_string_parameters, &query_string_parameters)),
+        ))
+        .extension(RawHttpPath(raw_path))
+        .extension(QueryStringParameters(query_string_parameters))
+        .extension(RequestContext::VpcLattice(vlr.request_context));
+
+    let base64 = vlr.is_base64_encoded;
+
+    let mut req = builder
+        .body(
+            vlr
+                .body
+                .as_deref()
+                .map_or_else(Body::default, |b| Body::from_maybe_encoded(base64, b)),
+        )
+        .expect("failed to build request");
+
+    // no builder method that sets headers in batch
+    let _ = std::mem::replace(req.headers_mut(), vlr.headers);
+    let _ = std::mem::replace(req.method_mut(), http_method.unwrap_or(http::Method::GET));
+
+    req
+}
 #[cfg(feature = "pass_through")]
 fn into_pass_through_request(data: String) -> http::Request<Body> {
     let mut builder = http::Request::builder();
@@ -393,6 +442,9 @@ pub enum RequestContext {
     /// WebSocket request context
     #[cfg(feature = "apigw_websockets")]
     WebSocket(ApiGatewayWebsocketProxyRequestContext),
+    /// VPC Lattice request context
+    #[cfg(feature = "vpc_lattice")]
+    VpcLattice(VpcLatticeRequestV2Context),
     /// Custom request context
     #[cfg(feature = "pass_through")]
     PassThrough,
@@ -410,6 +462,8 @@ impl From<LambdaRequest> for http::Request<Body> {
             LambdaRequest::Alb(alb) => into_alb_request(alb),
             #[cfg(feature = "apigw_websockets")]
             LambdaRequest::WebSocket(ag) => into_websocket_request(ag),
+            #[cfg(feature = "vpc_lattice")]
+            LambdaRequest::VpcLatticeV2(vpclat) => into_vpc_lattice_request(vpclat),
             #[cfg(feature = "pass_through")]
             LambdaRequest::PassThrough(data) => into_pass_through_request(data),
         }
@@ -770,6 +824,183 @@ mod tests {
                 .query_string_parameters_ref()
                 .and_then(|params| params.all("myKey")),
             Some(vec!["?showAll=true", "?showAll=false"])
+        );
+    }
+
+    #[test]
+    fn deserializes_vpc_lattice_basic() {
+        let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event is was not parsed as expected {result:?} given {input}"
+        );
+        let request = result.expect("failed to parse request");
+        assert_eq!(request.method(), "GET");
+
+        let body_str = match request.body() {
+            Body::Text(s) => s.as_str(),
+            _ => ""
+        };
+
+        assert_eq!(body_str, "All is good");
+
+        let uri = request.uri().to_string();
+        assert!(uri.starts_with("/health?"), "unexpected uri: {uri}");
+        assert!(uri.contains("multi=a"), "unexpected uri: {uri}");
+        assert!(uri.contains("multi=DEF"), "unexpected uri: {uri}");
+        assert!(uri.contains("multi=g"), "unexpected uri: {uri}");
+        assert!(uri.contains("state=prod"), "unexpected uri: {uri}");
+
+        // Ensure this is an VPC Lattice request
+        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        assert!(
+            matches!(req_context, &RequestContext::VpcLattice(_)),
+            "expected Vpc lattice context, got {req_context:?}"
+        );
+    }
+
+    #[test]
+    fn deserializes_vpc_lattice_basic_base64() {
+        let input = include_str!("../tests/data/vpc_lattice_v2_request_base64.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event is was not parsed as expected {result:?} given {input}"
+        );
+        let request = result.expect("failed to parse request");
+        assert_eq!(request.method(), "GET");
+
+        let body_array = match request.body() {
+            Body::Binary(s) => s.as_slice(),
+            _ => &[]
+        };
+
+        assert_eq!(body_array, *b"All is good");
+
+        // URI should have been built from host header, query and protocol etc
+        let uri = request.uri();
+
+        assert!(uri.to_string().starts_with("https://www.site.com/health?"));
+        assert!(uri.to_string().contains("multi=a&multi=DEF&multi=g"));
+        assert!(uri.to_string().contains("state=prod"));
+
+        // Ensure this is an VPC Lattice request
+        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        assert!(
+            matches!(req_context, &RequestContext::VpcLattice(_)),
+            "expected Vpc lattice context, got {req_context:?}"
+        );
+    }
+
+    #[test]
+    fn deserializes_vpc_lattice_headers() {
+        let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event is was not parsed as expected {result:?} given {input}"
+        );
+        let request = result.expect("failed to parse request");
+
+        // decoding multi value headers
+        let multi_headers_as_big_string = request
+            .headers()
+            .get_all("multi")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .reduce(|acc, nxt| [acc, nxt].join(";"));
+
+        assert_eq!(multi_headers_as_big_string, Some("x;y".to_string()));
+
+        // decoding regular headers
+        let basic_headers_as_big_string = request
+            .headers()
+            .get_all("user-agent")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .reduce(|acc, nxt| [acc, nxt].join(";"));
+
+        assert_eq!(basic_headers_as_big_string, Some("curl/7.68.0".to_string()));
+
+        // Ensure this is an VPC Lattice request
+        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        assert!(
+            matches!(req_context, &RequestContext::VpcLattice(_)),
+            "expected Vpc lattice context, got {req_context:?}"
+        );
+    }
+
+    #[test]
+    fn deserializes_vpc_lattice_multi_value_querys() {
+        let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event is was not parsed as expected {result:?} given {input}"
+        );
+        let request = result.expect("failed to parse request");
+        assert!(!request
+            .query_string_parameters_ref()
+            .expect("Request is missing query parameters")
+            .is_empty());
+
+        let params = request.query_string_parameters();
+        assert_eq!(Some(vec!["prod"]), params.all("state"));
+        assert_eq!(Some(vec!["a", "DEF", "g"]), params.all("multi"));
+
+        let query = request.uri().query().unwrap();
+        assert!(query.contains("multi=a&multi=DEF&multi=g"));
+        assert!(query.contains("state=prod"));
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn deserializes_vpc_lattice_encoded_query_parameters() {
+        let input = include_str!("../tests/data/vpc_lattice_v2_request_encoded_query.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event is was not parsed as expected {result:?} given {input}"
+        );
+        let request = result.expect("failed to parse request");
+
+        let params = request.query_string_parameters();
+        // percent-encoded values should be decoded
+        assert_eq!(Some(vec!["?showAll=true"]), params.all("filter"));
+        assert_eq!(Some(vec!["hello world"]), params.all("q"));
+
+        let query = request.uri().query().unwrap();
+        assert!(query.contains("filter="), "unexpected uri query: {query}");
+        assert!(query.contains("q="), "unexpected uri query: {query}");
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn deserializes_vpc_lattice_no_body() {
+        let input = r#"{
+            "version": "2.0",
+            "path": "/ping",
+            "method": "GET",
+            "headers": {"accept": ["*/*"]},
+            "queryStringParameters": {},
+            "isBase64Encoded": false,
+            "requestContext": {
+                "serviceNetworkArn": "arn:aws:vpc-lattice:us-east-1:123456789012:servicenetwork/sn-abc",
+                "serviceArn": "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-abc",
+                "targetGroupArn": "arn:aws:vpc-lattice:us-east-1:123456789012:targetgroup/tg-abc",
+                "region": "us-east-1",
+                "timeEpoch": "1724875399456789"
+            }
+        }"#;
+        let result = from_str(input);
+        assert!(result.is_ok(), "event was not parsed as expected {result:?}");
+        let request = result.expect("failed to parse request");
+        assert_eq!(request.method(), "GET");
+        assert!(
+            matches!(request.body(), Body::Empty),
+            "expected empty body, got {:?}",
+            request.body()
         );
     }
 

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -349,7 +349,6 @@ fn into_websocket_request(ag: ApiGatewayWebsocketProxyRequest) -> http::Request<
     req
 }
 
-
 #[cfg(feature = "vpc_lattice")]
 fn into_vpc_lattice_request(vlr: VpcLatticeRequestV2) -> http::Request<Body> {
     let http_method = vlr.method;
@@ -373,8 +372,7 @@ fn into_vpc_lattice_request(vlr: VpcLatticeRequestV2) -> http::Request<Body> {
 
     let mut req = builder
         .body(
-            vlr
-                .body
+            vlr.body
                 .as_deref()
                 .map_or_else(Body::default, |b| Body::from_maybe_encoded(base64, b)),
         )
@@ -840,7 +838,7 @@ mod tests {
 
         let body_str = match request.body() {
             Body::Text(s) => s.as_str(),
-            _ => ""
+            _ => "",
         };
 
         assert_eq!(body_str, "All is good");
@@ -853,7 +851,9 @@ mod tests {
         assert!(uri.contains("state=prod"), "unexpected uri: {uri}");
 
         // Ensure this is an VPC Lattice request
-        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        let req_context = request
+            .request_context_ref()
+            .expect("Request is missing RequestContext");
         assert!(
             matches!(req_context, &RequestContext::VpcLattice(_)),
             "expected Vpc lattice context, got {req_context:?}"
@@ -873,7 +873,7 @@ mod tests {
 
         let body_array = match request.body() {
             Body::Binary(s) => s.as_slice(),
-            _ => &[]
+            _ => &[],
         };
 
         assert_eq!(body_array, *b"All is good");
@@ -886,7 +886,9 @@ mod tests {
         assert!(uri.to_string().contains("state=prod"));
 
         // Ensure this is an VPC Lattice request
-        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        let req_context = request
+            .request_context_ref()
+            .expect("Request is missing RequestContext");
         assert!(
             matches!(req_context, &RequestContext::VpcLattice(_)),
             "expected Vpc lattice context, got {req_context:?}"
@@ -924,7 +926,9 @@ mod tests {
         assert_eq!(basic_headers_as_big_string, Some("curl/7.68.0".to_string()));
 
         // Ensure this is an VPC Lattice request
-        let req_context = request.request_context_ref().expect("Request is missing RequestContext");
+        let req_context = request
+            .request_context_ref()
+            .expect("Request is missing RequestContext");
         assert!(
             matches!(req_context, &RequestContext::VpcLattice(_)),
             "expected Vpc lattice context, got {req_context:?}"

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -384,6 +384,7 @@ fn into_vpc_lattice_request(vlr: VpcLatticeRequestV2) -> http::Request<Body> {
 
     req
 }
+
 #[cfg(feature = "pass_through")]
 fn into_pass_through_request(data: String) -> http::Request<Body> {
     let mut builder = http::Request::builder();
@@ -479,7 +480,7 @@ impl RequestContext {
             Self::ApiGatewayV2(ag) => ag.authorizer.as_ref(),
             #[cfg(feature = "apigw_websockets")]
             Self::WebSocket(ag) => Some(&ag.authorizer),
-            #[cfg(any(feature = "alb", feature = "pass_through"))]
+            #[cfg(any(feature = "alb", feature = "pass_through", feature = "vpc_lattice"))]
             _ => None,
         }
     }
@@ -826,6 +827,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "vpc_lattice")]
     fn deserializes_vpc_lattice_basic() {
         let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
         let result = from_str(input);
@@ -861,6 +863,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "vpc_lattice")]
     fn deserializes_vpc_lattice_basic_base64() {
         let input = include_str!("../tests/data/vpc_lattice_v2_request_base64.json");
         let result = from_str(input);
@@ -896,6 +899,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "vpc_lattice")]
     fn deserializes_vpc_lattice_headers() {
         let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
         let result = from_str(input);
@@ -936,6 +940,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "vpc_lattice")]
     fn deserializes_vpc_lattice_multi_value_querys() {
         let input = include_str!("../tests/data/vpc_lattice_v2_request.json");
         let result = from_str(input);
@@ -1178,5 +1183,66 @@ mod tests {
         let req_context = req.request_context_ref().expect("Request is missing RequestContext");
         let authorizer = req_context.authorizer().expect("authorizer is missing");
         assert_eq!(Some("admin"), authorizer.fields.get("principalId").unwrap().as_str());
+    }
+
+    #[test]
+    #[cfg(all(feature = "apigw_http", feature = "vpc_lattice"))]
+    fn vpc_lattice_event_does_not_match_apigw_v2() {
+        let data = include_bytes!("../../lambda-events/src/fixtures/example-vpc-lattice-v2-request.json");
+        let result = serde_json::from_slice::<ApiGatewayV2httpRequest>(data);
+        assert!(result.is_err(), "VPC Lattice event should not deserialize as APIGW V2");
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn vpc_lattice_method_none_defaults_to_get() {
+        let input = r#"{
+            "version": "2.0",
+            "path": "/ping",
+            "headers": {"accept": ["*/*"]},
+            "queryStringParameters": {},
+            "isBase64Encoded": false,
+            "requestContext": {
+                "serviceNetworkArn": "arn:aws:vpc-lattice:us-east-1:123456789012:servicenetwork/sn-abc",
+                "serviceArn": "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-abc",
+                "targetGroupArn": "arn:aws:vpc-lattice:us-east-1:123456789012:targetgroup/tg-abc",
+                "region": "us-east-1",
+                "timeEpoch": "1724875399456789"
+            }
+        }"#;
+        let result = from_str(input);
+        assert!(result.is_ok(), "event was not parsed as expected {result:?}");
+        let request = result.expect("failed to parse request");
+        assert_eq!(request.method(), "GET");
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn vpc_lattice_post_with_body() {
+        let input = r#"{
+            "version": "2.0",
+            "path": "/submit",
+            "method": "POST",
+            "headers": {"content-type": ["application/json"]},
+            "queryStringParameters": {},
+            "body": "{\"key\":\"value\"}",
+            "isBase64Encoded": false,
+            "requestContext": {
+                "serviceNetworkArn": "arn:aws:vpc-lattice:us-east-1:123456789012:servicenetwork/sn-abc",
+                "serviceArn": "arn:aws:vpc-lattice:us-east-1:123456789012:service/svc-abc",
+                "targetGroupArn": "arn:aws:vpc-lattice:us-east-1:123456789012:targetgroup/tg-abc",
+                "region": "us-east-1",
+                "timeEpoch": "1724875399456789"
+            }
+        }"#;
+        let result = from_str(input);
+        assert!(result.is_ok(), "event was not parsed as expected {result:?}");
+        let request = result.expect("failed to parse request");
+        assert_eq!(request.method(), "POST");
+        let body_str = match request.body() {
+            Body::Text(s) => s.as_str(),
+            other => panic!("expected text body, got {other:?}"),
+        };
+        assert_eq!(body_str, r#"{"key":"value"}"#);
     }
 }

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -7,9 +7,9 @@ use aws_lambda_events::alb::AlbTargetGroupResponse;
 use aws_lambda_events::apigw::ApiGatewayProxyResponse;
 #[cfg(feature = "apigw_http")]
 use aws_lambda_events::apigw::ApiGatewayV2httpResponse;
+use aws_lambda_events::encodings::Body;
 #[cfg(feature = "vpc_lattice")]
 use aws_lambda_events::vpc_lattice::VpcLatticeResponse;
-use aws_lambda_events::encodings::Body;
 use encoding_rs::Encoding;
 use http::{
     header::{CONTENT_ENCODING, CONTENT_TYPE},
@@ -170,7 +170,7 @@ impl LambdaResponse {
 
                 response.body = body;
                 response.is_base64_encoded = is_base64_encoded;
-                response.status_code = status_code as u16;
+                response.status_code = status_code;
                 response.headers = headers;
                 // Today, this implementation doesn't provide any additional fields
                 #[cfg(feature = "catch-all-fields")]
@@ -633,10 +633,7 @@ mod tests {
                 .expect("failed to create response"),
         );
         let json = serde_json::to_string(&res).expect("failed to serialize to json");
-        assert_eq!(
-            json,
-            r#"{"isBase64Encoded":true,"statusCode":200,"body":"aGVsbG8="}"#
-        );
+        assert_eq!(json, r#"{"isBase64Encoded":true,"statusCode":200,"body":"aGVsbG8="}"#);
     }
 
     #[test]

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -7,6 +7,8 @@ use aws_lambda_events::alb::AlbTargetGroupResponse;
 use aws_lambda_events::apigw::ApiGatewayProxyResponse;
 #[cfg(feature = "apigw_http")]
 use aws_lambda_events::apigw::ApiGatewayV2httpResponse;
+#[cfg(feature = "vpc_lattice")]
+use aws_lambda_events::vpc_lattice::VpcLatticeResponse;
 use aws_lambda_events::encodings::Body;
 use encoding_rs::Encoding;
 use http::{
@@ -51,6 +53,8 @@ pub enum LambdaResponse {
     ApiGatewayV2(ApiGatewayV2httpResponse),
     #[cfg(feature = "alb")]
     Alb(AlbTargetGroupResponse),
+    #[cfg(feature = "vpc_lattice")]
+    VpcLattice(VpcLatticeResponse),
     #[cfg(feature = "pass_through")]
     PassThrough(serde_json::Value),
 }
@@ -160,6 +164,21 @@ impl LambdaResponse {
                 }
                 response
             }),
+            #[cfg(feature = "vpc_lattice")]
+            RequestOrigin::VpcLatticeV2 => LambdaResponse::VpcLattice({
+                let mut response = VpcLatticeResponse::default();
+
+                response.body = body;
+                response.is_base64_encoded = is_base64_encoded;
+                response.status_code = status_code as u16;
+                response.headers = headers;
+                // Today, this implementation doesn't provide any additional fields
+                #[cfg(feature = "catch-all-fields")]
+                {
+                    response.other = Default::default();
+                }
+                response
+            }),
             #[cfg(feature = "pass_through")]
             RequestOrigin::PassThrough => {
                 match body {
@@ -173,9 +192,10 @@ impl LambdaResponse {
                 feature = "apigw_rest",
                 feature = "apigw_http",
                 feature = "alb",
-                feature = "apigw_websockets"
+                feature = "apigw_websockets",
+                feature = "vpc_lattice"
             )))]
-            _ => compile_error!("Either feature `apigw_rest`, `apigw_http`, `alb`, or `apigw_websockets` must be enabled for the `lambda-http` crate."),
+            _ => compile_error!("Either feature `apigw_rest`, `apigw_http`, `alb`, `apigw_websockets` or `vpc_lattice` must be enabled for the `lambda-http` crate."),
         }
     }
 }
@@ -582,6 +602,59 @@ mod tests {
             json,
             r#"{"statusCode":200,"headers":{},"multiValueHeaders":{},"body":"000000","isBase64Encoded":false,"cookies":[]}"#
         )
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn serialize_vpc_lattice_response_text_body() {
+        let res = LambdaResponse::from_response(
+            &RequestOrigin::VpcLatticeV2,
+            Response::builder()
+                .status(200)
+                .header("content-type", "text/plain")
+                .body(Body::from("hello"))
+                .expect("failed to create response"),
+        );
+        let json = serde_json::to_string(&res).expect("failed to serialize to json");
+        assert_eq!(
+            json,
+            r#"{"isBase64Encoded":false,"statusCode":200,"headers":{"content-type":"text/plain"},"body":"hello"}"#
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn serialize_vpc_lattice_response_binary_body() {
+        let res = LambdaResponse::from_response(
+            &RequestOrigin::VpcLatticeV2,
+            Response::builder()
+                .status(200)
+                .body(Body::from(b"hello".as_slice()))
+                .expect("failed to create response"),
+        );
+        let json = serde_json::to_string(&res).expect("failed to serialize to json");
+        assert_eq!(
+            json,
+            r#"{"isBase64Encoded":true,"statusCode":200,"body":"aGVsbG8="}"#
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "vpc_lattice")]
+    fn serialize_vpc_lattice_response_non_200_status() {
+        let res = LambdaResponse::from_response(
+            &RequestOrigin::VpcLatticeV2,
+            Response::builder()
+                .status(404)
+                .header("x-request-id", "abc-123")
+                .body(Body::from(()))
+                .expect("failed to create response"),
+        );
+        let json = serde_json::to_string(&res).expect("failed to serialize to json");
+        assert_eq!(
+            json,
+            r#"{"isBase64Encoded":false,"statusCode":404,"headers":{"x-request-id":"abc-123"},"body":null}"#
+        );
     }
 
     #[test]

--- a/lambda-http/tests/data/vpc_lattice_v2_request.json
+++ b/lambda-http/tests/data/vpc_lattice_v2_request.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0",
+  "path": "/health",
+  "method": "GET",
+  "headers": {
+    "accept": ["*/*"],
+    "user-agent": ["curl/7.68.0"],
+    "x-forwarded-for": ["10.0.2.100"],
+    "multi": ["x", "y"]
+  },
+  "queryStringParameters": {
+    "state": ["prod"],
+    "multi": ["a", "DEF", "g"]
+  },
+  "body": "All is good",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "serviceNetworkArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:servicenetwork/sn-0bf3f2882e9cc805a",
+    "serviceArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:service/svc-0a40eebed65f8d69c",
+    "targetGroupArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09",
+    "identity": {
+      "sourceVpcArn": "arn:aws:ec2:ap-southeast-2:123456789012:vpc/vpc-0b8276c84697e7339",
+      "type": "AWS_IAM",
+      "principal": "arn:aws:iam::123456789012:role/service-role/HealthChecker",
+      "principalOrgID": "o-50dc6c495c0c9188"
+    },
+    "region": "ap-southeast-2",
+    "timeEpoch": "1724875399456789"
+  }
+}

--- a/lambda-http/tests/data/vpc_lattice_v2_request_base64.json
+++ b/lambda-http/tests/data/vpc_lattice_v2_request_base64.json
@@ -1,0 +1,31 @@
+{
+  "version": "2.0",
+  "path": "/health",
+  "method": "GET",
+  "headers": {
+    "host": "www.site.com",
+    "accept": ["*/*"],
+    "user-agent": ["curl/7.68.0"],
+    "x-forwarded-for": ["10.0.2.100"],
+    "multi": ["x", "y"]
+  },
+  "queryStringParameters": {
+    "state": ["prod"],
+    "multi": ["a", "DEF", "g"]
+  },
+  "body": "QWxsIGlzIGdvb2Q=",
+  "isBase64Encoded": true,
+  "requestContext": {
+    "serviceNetworkArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:servicenetwork/sn-0bf3f2882e9cc805a",
+    "serviceArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:service/svc-0a40eebed65f8d69c",
+    "targetGroupArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09",
+    "identity": {
+      "sourceVpcArn": "arn:aws:ec2:ap-southeast-2:123456789012:vpc/vpc-0b8276c84697e7339",
+      "type": "AWS_IAM",
+      "principal": "arn:aws:iam::123456789012:role/service-role/HealthChecker",
+      "principalOrgID": "o-50dc6c495c0c9188"
+    },
+    "region": "ap-southeast-2",
+    "timeEpoch": "1724875399456789"
+  }
+}

--- a/lambda-http/tests/data/vpc_lattice_v2_request_encoded_query.json
+++ b/lambda-http/tests/data/vpc_lattice_v2_request_encoded_query.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0",
+  "path": "/search",
+  "method": "GET",
+  "headers": {
+    "host": ["api.example.com"],
+    "accept": ["*/*"]
+  },
+  "queryStringParameters": {
+    "filter": ["%3FshowAll%3Dtrue"],
+    "q": ["hello%20world"]
+  },
+  "isBase64Encoded": false,
+  "requestContext": {
+    "serviceNetworkArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:servicenetwork/sn-0bf3f2882e9cc805a",
+    "serviceArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:service/svc-0a40eebed65f8d69c",
+    "targetGroupArn": "arn:aws:vpc-lattice:ap-southeast-2:123456789012:targetgroup/tg-6d0ecf831eec9f09",
+    "region": "ap-southeast-2",
+    "timeEpoch": "1724875399456789"
+  }
+}


### PR DESCRIPTION
📬 *Issue #, if available:*

#1029 

✍️ *Description of changes:*

Added VPC Lattice support (and test cases) to lambda-http.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
