### PR TITLE
fix(lambda-http): into_api_gateway_v2_request joins cookies with "; "

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -147,7 +147,7 @@ fn into_api_gateway_v2_request(ag: ApiGatewayV2httpRequest) -> http::Request<Bod
 
     let mut headers = ag.headers;
     if let Some(cookies) = ag.cookies {
-        if let Ok(header_value) = HeaderValue::from_str(&cookies.join(";")) {
+        if let Ok(header_value) = HeaderValue::from_str(&cookies.join("; ")) {
             headers.insert(http::header::COOKIE, header_value);
         }
     }
@@ -570,7 +570,7 @@ mod tests {
 
         assert_eq!(req.method(), "POST");
         assert_eq!(req.uri(), "https://id.execute-api.us-east-1.amazonaws.com/my/path?parameter1=value1&parameter1=value2&parameter2=value");
-        assert_eq!(cookie_header, Ok("cookie1=value1;cookie2=value2"));
+        assert_eq!(cookie_header, Ok("cookie1=value1; cookie2=value2"));
 
         // Ensure this is an APIGWv2 request
         let req_context = req.request_context_ref().expect("Request is missing RequestContext");


### PR DESCRIPTION
`into_api_gateway_v2_request` reconstructs the Cookie header by joining the cookies array from the API Gateway v2 event payload with `";"` (no space). This violates RFC 6265 §4.2.1, which mandates `"; "` (semicolon followed by a space) as the cookie-pair separator. The result is a non-compliant Cookie header that breaks any downstream cookie parser that follows the spec strictly like BetterAuth.

📬 *Issue #, if available:*

Closes https://github.com/aws/aws-lambda-rust-runtime/issues/1142

✍️ *Description of changes:*

The `Cookie` header reconstructed from `into_api_gateway_v2_request` now joins pairs with `"; "` to produce a spec-compliant value:
 
```
cookie1=value1; cookie2=value2
```

The corresponding test was updated.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
