### PR TITLE
chore: release v1.2.0

### DIFF
--- a/lambda-events/CHANGELOG.md
+++ b/lambda-events/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.3...aws_lambda_events-v1.2.0) - 2026-05-08
+
+### Added
+
+- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))
+
 ## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.2...aws_lambda_events-v1.1.3) - 2026-04-16
 
 ### Other

--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_lambda_events"
-version = "1.1.3"
+version = "1.2.0"
 rust-version = "1.84.0"
 description = "AWS Lambda event definitions"
 authors = [

--- a/lambda-http/CHANGELOG.md
+++ b/lambda-http/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.3...lambda_http-v1.2.0) - 2026-05-08
+
+### Added
+
+- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))
+
+### Fixed
+
+- *(lambda-http)* into_api_gateway_v2_request joins cookies with "; " ([#1143](https://github.com/aws/aws-lambda-rust-runtime/pull/1143))
+
+### Other
+
+- Added `builders` pass-through feature to enable `aws_lambda_events/builders` ([#1146](https://github.com/aws/aws-lambda-rust-runtime/pull/1146))
+
 ## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.2...lambda_http-v1.1.3) - 2026-04-16
 
 ### Other

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "1.1.3"
+version = "1.2.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -41,7 +41,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.1.3", path = "../lambda-runtime", default-features = false}
+lambda_runtime = { version = "1.2.0", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
@@ -53,7 +53,7 @@ url = "2.2"
 
 [dependencies.aws_lambda_events]
 path = "../lambda-events"
-version = "1.1"
+version = "1.2"
 default-features = false
 features = ["alb", "apigw", "vpc_lattice"]
 

--- a/lambda-runtime/CHANGELOG.md
+++ b/lambda-runtime/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.3...lambda_runtime-v1.2.0) - 2026-05-08
+
+### Added
+
+- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))
+
+### Fixed
+
+- *(lambda-http)* into_api_gateway_v2_request joins cookies with "; " ([#1143](https://github.com/aws/aws-lambda-rust-runtime/pull/1143))
+
+### Other
+
+- Added `builders` pass-through feature to enable `aws_lambda_events/builders` ([#1146](https://github.com/aws/aws-lambda-rust-runtime/pull/1146))
+
 ## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.2...lambda_runtime-v1.1.3) - 2026-04-16
 
 ### Other

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "1.1.3"
+version = "1.2.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION



## 🤖 New release

* `aws_lambda_events`: 1.1.3 -> 1.2.0 (✓ API compatible changes)
* `lambda_runtime`: 1.1.3 -> 1.2.0 (✓ API compatible changes)
* `lambda_http`: 1.1.3 -> 1.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `aws_lambda_events`

<blockquote>

## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.3...aws_lambda_events-v1.2.0) - 2026-05-08

### Added

- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))
</blockquote>

## `lambda_runtime`

<blockquote>

## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.3...lambda_runtime-v1.2.0) - 2026-05-08

### Added

- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))

### Fixed

- *(lambda-http)* into_api_gateway_v2_request joins cookies with "; " ([#1143](https://github.com/aws/aws-lambda-rust-runtime/pull/1143))

### Other

- Added `builders` pass-through feature to enable `aws_lambda_events/builders` ([#1146](https://github.com/aws/aws-lambda-rust-runtime/pull/1146))
</blockquote>

## `lambda_http`

<blockquote>

## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.3...lambda_http-v1.2.0) - 2026-05-08

### Added

- Add VPC Lattice as an upstream source for lambda-http ([#1136](https://github.com/aws/aws-lambda-rust-runtime/pull/1136))

### Fixed

- *(lambda-http)* into_api_gateway_v2_request joins cookies with "; " ([#1143](https://github.com/aws/aws-lambda-rust-runtime/pull/1143))

### Other

- Added `builders` pass-through feature to enable `aws_lambda_events/builders` ([#1146](https://github.com/aws/aws-lambda-rust-runtime/pull/1146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).