### PR TITLE
[lambda_http]: Added `builders` pass-through feature to enable `aws_lambda_events/builders`

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -24,6 +24,7 @@ apigw_websockets = []
 alb = []
 vpc_lattice = []
 pass_through = []
+builders = ["aws_lambda_events/builders"]
 catch-all-fields = ["aws_lambda_events/catch-all-fields"]
 tracing = ["lambda_runtime/tracing"] # enables access to the Tracing utilities
 opentelemetry = ["lambda_runtime/opentelemetry"] # enables access to the OpenTelemetry layers and utilities

--- a/lambda-http/README.md
+++ b/lambda-http/README.md
@@ -252,6 +252,8 @@ The available feature flags for `lambda_http` are the following:
 - `apigw_http`: for events coming from [Amazon API Gateway HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) and [AWS Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html).
 - `apigw_websockets`: for events coming from [Amazon API Gateway WebSockets](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
 - `vpc_lattice`: for events coming from [AWS VPC Lattice](https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html).
+- `catch-all-fields`: enables catch-all fields in event types to preserve unknown JSON fields during deserialization.
+- `builders`: enables builder pattern support for request/response types in `aws_lambda_events`, useful for constructing test fixtures.
 
 If you only want to support one of these sources, you can disable the default features, and enable only the source that you care about in your package's `Cargo.toml` file. Substitute the dependency line for `lambda_http` for the snippet below, changing the feature that you want to enable:
 


### PR DESCRIPTION
📬 *Issue #, if available:*
Fixes #1141

✍️ *Description of changes:*
Added `builders` feature to `lambda_http` to enable the same feature on `aws_lambda_events`.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
