### PR TITLE
Fixing Integration tests concurrency 

### DIFF
--- a/.github/workflows/run-integration-test.yml
+++ b/.github/workflows/run-integration-test.yml
@@ -13,6 +13,9 @@ jobs:
     # Only run on the main repo, not forks
     if: ${{ github.repository_owner == 'aws' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: integration-test
+      cancel-in-progress: false
     steps:
         - name: install Cargo Lambda
           uses: jaxxstorm/action-install-gh-release@v2.1.0


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

`release-plz` can cause multiple run-integration-test workflow s to run at once, we need to limit concurrency to avoid the following errors on CloudFormation:

```
Stack name = aws-lambda-rust-integ-test-25579182302

File with same data already exists at 075e2c46de8a1bc1c6e567986d8c30fc, skipping upload

File with same data already exists at cdf058086948fb2da15dd1276cd103e5, skipping upload

File with same data already exists at 959b91d197150e2cd55715e4508d4ea3, skipping upload

File with same data already exists at 139801cd7679714fdad7e1a894a96c29.template, skipping upload

Error: Failed to create/update the stack: aws-lambda-rust-integ-test-25579182302, Waiter StackCreateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "ROLLBACK_COMPLETE" at least once
```


| Branch | Started | Ended | Result | Link |
|--------|---------|-------|--------|------|
| `main` | 20:53:06 | 21:00:37 | ✓ success | [Run](https://github.com/aws/aws-lambda-rust-runtime/actions/runs/25578993199) |
| `aws_lambda_events-v1.2.0` | 20:57:33 | 21:00:55 | ✗ failure | [Run](https://github.com/aws/aws-lambda-rust-runtime/actions/runs/25579182302) |
| `lambda_runtime-v1.2.0` | 20:57:49 | 21:01:22 | ✗ failure | [Run](https://github.com/aws/aws-lambda-rust-runtime/actions/runs/25579193053) |
| `lambda_http-v1.2.0` | 20:58:09 | 21:01:18 | ✗ failure | [Run](https://github.com/aws/aws-lambda-rust-runtime/actions/runs/25579208375) |


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
