### PR TITLE
chore: release v1.2.1

### DIFF
--- a/lambda-http/CHANGELOG.md
+++ b/lambda-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.0...lambda_http-v1.2.1) - 2026-05-25
+
+### Other
+
+- updated the following local packages: lambda_runtime
+
 ## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.3...lambda_http-v1.2.0) - 2026-05-08
 
 ### Added

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -41,7 +41,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.2.0", path = "../lambda-runtime", default-features = false}
+lambda_runtime = { version = "1.2.1", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }

--- a/lambda-runtime/CHANGELOG.md
+++ b/lambda-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.0...lambda_runtime-v1.2.1) - 2026-05-25
+
+### Other
+
+- *(deps)* update opentelemetry-semantic-conventions requirement ([#1147](https://github.com/aws/aws-lambda-rust-runtime/pull/1147))
+
 ## [1.2.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.3...lambda_runtime-v1.2.0) - 2026-05-08
 
 ### Added

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION



## 🤖 New release

* `lambda_runtime`: 1.2.0 -> 1.2.1 (✓ API compatible changes)
* `lambda_http`: 1.2.0 -> 1.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `lambda_runtime`

<blockquote>

## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.0...lambda_runtime-v1.2.1) - 2026-05-25

### Other

- *(deps)* update opentelemetry-semantic-conventions requirement ([#1147](https://github.com/aws/aws-lambda-rust-runtime/pull/1147))
</blockquote>

## `lambda_http`

<blockquote>

## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.0...lambda_http-v1.2.1) - 2026-05-25

### Other

- updated the following local packages: lambda_runtime
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).