### PR TITLE
chore: release

### DIFF
--- a/lambda-extension/CHANGELOG.md
+++ b/lambda-extension/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.0.4...lambda-extension-v1.1.0) - 2026-07-09
+
+### Added
+
+- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
+
 ## [1.0.4](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.0.3...lambda-extension-v1.0.4) - 2026-03-19
 
 ### Other

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "1.0.4"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.84.0"
 authors = [

--- a/lambda-http/CHANGELOG.md
+++ b/lambda-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.1...lambda_http-v1.3.0) - 2026-07-09
+
+### Added
+
+- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
+
 ## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.0...lambda_http-v1.2.1) - 2026-05-25
 
 ### Other

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -41,7 +41,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.2.1", path = "../lambda-runtime", default-features = false}
+lambda_runtime = { version = "1.3.0", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }

--- a/lambda-runtime-api-client/CHANGELOG.md
+++ b/lambda-runtime-api-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.0.3...lambda_runtime_api_client-v1.1.0) - 2026-07-09
+
+### Added
+
+- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
+
 ### Added
 
 - `PooledClient`: a Runtime API client that can rebuild its connection pool after a

--- a/lambda-runtime/CHANGELOG.md
+++ b/lambda-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.1...lambda_runtime-v1.3.0) - 2026-07-09
+
+### Added
+
+- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
+
 ## [1.2.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.0...lambda_runtime-v1.2.1) - 2026-05-25
 
 ### Other

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -41,7 +41,7 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 http-serde = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client"] }
-lambda-extension = { version = "1.0", path = "../lambda-extension", default-features = false, optional = true }
+lambda-extension = { version = "1.1", path = "../lambda-extension", default-features = false, optional = true }
 lambda_runtime_api_client = { version = "1.1.0", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.32", optional = true, features = ["semconv_experimental"] }


### PR DESCRIPTION



## 🤖 New release

* `lambda_runtime_api_client`: 1.0.3 -> 1.1.0
* `lambda-extension`: 1.0.4 -> 1.1.0 (✓ API compatible changes)
* `lambda_runtime`: 1.2.1 -> 1.3.0 (✓ API compatible changes)
* `lambda_http`: 1.2.1 -> 1.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `lambda_runtime_api_client`

<blockquote>

## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.0.3...lambda_runtime_api_client-v1.1.0) - 2026-07-09

### Added

- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))

### Added

- `PooledClient`: a Runtime API client that can rebuild its connection pool after a
  SnapStart VM restore via `reset_pool()`, so stale connections to the Runtime API
  (RAPID) are discarded. Implemented lock-free with `OnceLock`; `call()` has no
  hot-path lock. Construct via `PooledClient::builder().build()`.
- `PooledClientBuilder`, returned by `PooledClient::builder()`.
- `RuntimeApiClient` trait abstracting `call`, implemented by both `Client` and
  `PooledClient`.

### Deprecated

- `Client` and `ClientBuilder::build` are superseded by `PooledClient` /
  `PooledClient::builder().build()`. `Client` is unchanged and fully functional; it
  simply cannot reset its connection pool after a SnapStart restore. They are
  documented as superseded but do **not** carry a `#[deprecated]` attribute, so no
  compiler warnings are emitted; they are expected to be removed in the next major
  version (2.0.0). This keeps the crate non-breaking (no major version bump).
</blockquote>

## `lambda-extension`

<blockquote>

## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.0.4...lambda-extension-v1.1.0) - 2026-07-09

### Added

- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
</blockquote>

## `lambda_runtime`

<blockquote>

## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.1...lambda_runtime-v1.3.0) - 2026-07-09

### Added

- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
</blockquote>

## `lambda_http`

<blockquote>

## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.1...lambda_http-v1.3.0) - 2026-07-09

### Added

- add SnapStart support via SnapStartResource trait ([#1150](https://github.com/aws/aws-lambda-rust-runtime/pull/1150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).