### PR TITLE
chore: release

### DIFF
--- a/lambda-extension/CHANGELOG.md
+++ b/lambda-extension/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.1.0...lambda-extension-v1.1.1) - 2026-09-02
+
+### Other
+
+- updated the following local packages: lambda_runtime_api_client
+
 ## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.0.4...lambda-extension-v1.1.0) - 2026-07-09
 
 ### Added

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.84.0"
 authors = [
@@ -25,7 +25,7 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client", "server"] }
 hyper-util = { workspace = true }
-lambda_runtime_api_client = { version = "1.1.0", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "1.1.1", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tokio = { version = "1.0", features = [

--- a/lambda-http/CHANGELOG.md
+++ b/lambda-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.3.0...lambda_http-v1.3.1) - 2026-09-02
+
+### Other
+
+- updated the following local packages: lambda_runtime_api_client, lambda_runtime
+
 ## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.2.1...lambda_http-v1.3.0) - 2026-07-09
 
 ### Added

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -41,7 +41,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.3.0", path = "../lambda-runtime", default-features = false}
+lambda_runtime = { version = "1.4.0", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
@@ -61,7 +61,7 @@ features = ["alb", "apigw", "vpc_lattice"]
 axum-core = "0.5.4"
 
 axum-extra = { version = "0.12.5", features = ["query"] }
-lambda_runtime_api_client = { version = "1.1.0", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "1.1.1", path = "../lambda-runtime-api-client" }
 
 log = "^0.4"
 maplit = "1.0"

--- a/lambda-runtime-api-client/CHANGELOG.md
+++ b/lambda-runtime-api-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.1.0...lambda_runtime_api_client-v1.1.1) - 2026-09-02
+
+### Other
+
+- release ([#1151](https://github.com/aws/aws-lambda-rust-runtime/pull/1151))
+
 ## [1.1.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.0.3...lambda_runtime_api_client-v1.1.0) - 2026-07-09
 
 ### Added

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.84.0"
 authors = [

--- a/lambda-runtime/CHANGELOG.md
+++ b/lambda-runtime/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.3.0...lambda_runtime-v1.4.0) - 2026-09-02
+
+### Added
+
+- add lambda-runtime-invocation-id header ([#1159](https://github.com/aws/aws-lambda-rust-runtime/pull/1159))
+
+### Other
+
+- Record faas.name on Lambda OTEL spans. ([#1163](https://github.com/aws/aws-lambda-rust-runtime/pull/1163))
+- show custom event handler usage ([#1154](https://github.com/aws/aws-lambda-rust-runtime/pull/1154))
+- release ([#1151](https://github.com/aws/aws-lambda-rust-runtime/pull/1151))
+
 ## [1.3.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.2.1...lambda_runtime-v1.3.0) - 2026-07-09
 
 ### Added

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "1.3.0"
+version = "1.4.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -42,7 +42,7 @@ http-body-util = { workspace = true }
 http-serde = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client"] }
 lambda-extension = { version = "1.1", path = "../lambda-extension", default-features = false, optional = true }
-lambda_runtime_api_client = { version = "1.1.0", path = "../lambda-runtime-api-client", default-features = false }
+lambda_runtime_api_client = { version = "1.1.1", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.32", optional = true, features = ["semconv_experimental"] }
 pin-project = "1"


### PR DESCRIPTION



## 🤖 New release

* `lambda_runtime_api_client`: 1.1.0 -> 1.1.1 (✓ API compatible changes)
* `lambda_runtime`: 1.3.0 -> 1.4.0 (✓ API compatible changes)
* `lambda-extension`: 1.1.0 -> 1.1.1
* `lambda_http`: 1.3.0 -> 1.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `lambda_runtime_api_client`

<blockquote>

## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.1.0...lambda_runtime_api_client-v1.1.1) - 2026-09-02

### Other

- release ([#1151](https://github.com/aws/aws-lambda-rust-runtime/pull/1151))
</blockquote>

## `lambda_runtime`

<blockquote>

## [1.4.0](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.3.0...lambda_runtime-v1.4.0) - 2026-09-02

### Added

- add lambda-runtime-invocation-id header ([#1159](https://github.com/aws/aws-lambda-rust-runtime/pull/1159))

### Other

- Record faas.name on Lambda OTEL spans. ([#1163](https://github.com/aws/aws-lambda-rust-runtime/pull/1163))
- show custom event handler usage ([#1154](https://github.com/aws/aws-lambda-rust-runtime/pull/1154))
- release ([#1151](https://github.com/aws/aws-lambda-rust-runtime/pull/1151))
</blockquote>

## `lambda-extension`

<blockquote>

## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.1.0...lambda-extension-v1.1.1) - 2026-09-02

### Other

- updated the following local packages: lambda_runtime_api_client
</blockquote>

## `lambda_http`

<blockquote>

## [1.3.1](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.3.0...lambda_http-v1.3.1) - 2026-09-02

### Other

- updated the following local packages: lambda_runtime_api_client, lambda_runtime
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).