### PR TITLE
Fix SNS timestamp serialization to preserve millisecond precision

### DIFF
--- a/lambda-events/src/event/sns/mod.rs
+++ b/lambda-events/src/event/sns/mod.rs
@@ -1,12 +1,19 @@
 #[cfg(feature = "builders")]
 use bon::Builder;
-use chrono::{DateTime, Utc};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
 #[cfg(feature = "catch-all-fields")]
 use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_nullish;
+
+fn serialize_timestamp<S>(timestamp: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&timestamp.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
 
 /// The `Event` notification event handled by Lambda
 ///
@@ -85,6 +92,7 @@ pub struct SnsMessage {
     pub subject: Option<String>,
 
     /// The time (UTC) when the notification was published.
+    #[serde(serialize_with = "serialize_timestamp")]
     pub timestamp: DateTime<Utc>,
 
     /// Version of the Amazon SNS signature used.
@@ -166,6 +174,7 @@ pub struct SnsSubscriptionMessage {
     pub subject: Option<String>,
 
     /// The time (UTC) when the message was sent.
+    #[serde(serialize_with = "serialize_timestamp")]
     pub timestamp: DateTime<Utc>,
 
     /// Version of the Amazon SNS signature used.
@@ -289,6 +298,7 @@ pub struct SnsMessageObj<T: Serialize> {
     pub subject: Option<String>,
 
     /// The time (UTC) when the notification was published.
+    #[serde(serialize_with = "serialize_timestamp")]
     pub timestamp: DateTime<Utc>,
 
     /// Version of the Amazon SNS signature used.
@@ -594,5 +604,38 @@ mod test {
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: SnsSubscriptionMessage = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "sns")]
+    fn sns_timestamps_serialize_with_millisecond_precision() {
+        let mut data: serde_json::Value =
+            serde_json::from_slice(include_bytes!("../../fixtures/example-sns-event.json")).unwrap();
+        data["Records"][0]["Sns"]["Timestamp"] = serde_json::json!("2019-01-02T12:45:07.000Z");
+        let parsed: SnsEvent = serde_json::from_value(data).unwrap();
+        let serialized = serde_json::to_value(parsed).unwrap();
+        assert_eq!(
+            serialized["Records"][0]["Sns"]["Timestamp"].as_str(),
+            Some("2019-01-02T12:45:07.000Z")
+        );
+
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Message {
+            foo: String,
+            bar: i32,
+        }
+
+        let data = include_bytes!("../../fixtures/example-sns-event-obj.json");
+        let parsed: SnsEventObj<Message> = serde_json::from_slice(data).unwrap();
+        let serialized = serde_json::to_value(parsed).unwrap();
+        assert_eq!(
+            serialized["Records"][0]["Sns"]["Timestamp"].as_str(),
+            Some("2015-08-18T18:02:32.111Z")
+        );
+
+        let data = include_bytes!("../../fixtures/example-sns-subscription-confirmation.json");
+        let parsed: SnsSubscriptionMessage = serde_json::from_slice(data).unwrap();
+        let serialized = serde_json::to_value(parsed).unwrap();
+        assert_eq!(serialized["Timestamp"].as_str(), Some("2012-04-26T20:45:04.751Z"));
     }
 }


### PR DESCRIPTION
﻿﻿# Fix SNS timestamp serialization to preserve millisecond precision

## Summary

Fix SNS timestamp serialization so whole-second timestamps retain `.000` milliseconds.

Chrono omits the fractional component when serializing a `DateTime<Utc>` that falls exactly on a whole second. For SNS messages, that changes the serialized timestamp from forms such as:

`2025-01-01T12:34:56.000Z`

to:

`2025-01-01T12:34:56Z`

Because the SNS signature is computed over the original string representation, this changes the SNS string-to-sign and can cause signature verification to fail.

## Fix

Serialize the SNS `DateTime<Utc>` timestamp fields using RFC 3339 with fixed millisecond precision.

This ensures timestamps consistently retain three fractional digits, including `.000`, while leaving deserialization behavior and the public Rust types unchanged.

The change applies to:

* `SnsMessage`
* `SnsSubscriptionMessage`
* `SnsMessageObj`

## Regression coverage

Added coverage verifying that:

* a timestamp ending in `.000Z` survives a serialization/deserialization round-trip without losing its millisecond component;
* existing timestamps with nonzero milliseconds continue to serialize with exactly three fractional digits.

## Validation

* SNS module tests passed: **8 tests**
* `cargo fmt --all -- --check` passed
* SNS library Clippy passed with `-D warnings`

Full all-target Clippy is currently blocked by unrelated pre-existing warnings in API Gateway/fixture tests.

Fixes #1161
