### PR TITLE
feat: log worker count and max concurrency

### DIFF
--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -256,6 +256,13 @@ where
     ) -> Result<(), BoxError> {
         let limit = concurrency_limit as usize;
 
+        debug!(
+            event = "runtime_worker_pool_initializing",
+            worker_count = limit,
+            execution_environment_max_concurrency = limit,
+            "runtime worker pool initializing",
+        );
+
         // Use FuturesUnordered so we can observe worker exits as they happen,
         // rather than waiting for all workers to finish (join_all).
         let mut workers: FuturesUnordered<tokio::task::JoinHandle<(tokio::task::Id, Result<(), BoxError>)>> =


### PR DESCRIPTION
## Description

Emit a structured `DEBUG` log event when the Rust runtime initializes its worker pool for concurrent execution.

This provides visibility into the effective concurrency configuration for Lambda Managed Instances. The event is emitted once during runtime initialization, before workers are spawned, and is not emitted for individual invocations.

This is an initiative that has been taken also in other RICs https://github.com/aws/aws-lambda-java-libs/pull/646 to give customer more visibility on multiconcurrency.

Example event fields:

```json
{
  "level": "DEBUG",
  "fields": {
    "message": "runtime worker pool initializing",
    "event": "runtime_worker_pool_initializing",
    "worker_count": 17,
    "execution_environment_max_concurrency": 17
  }
}
```

The event is subject to the runtime’s existing log-level filtering and is visible when the function log level is configured for `DEBUG` or lower.

### Why the two values are currently the same

The Rust runtime currently has one resolved concurrency value: `concurrency_limit`.

During runtime initialization:

1. `AWS_LAMBDA_MAX_CONCURRENCY` is parsed into `concurrency_limit`.
2. `run_concurrent_inner` converts that value into `limit`.
3. The runtime creates exactly one worker task per concurrency slot.

Therefore:

```text
worker_count = concurrency_limit
execution_environment_max_concurrency = concurrency_limit
```

The two fields represent different concepts, matching the Java runtime’s event schema:

- `worker_count` describes how many polling workers this runtime creates.
- `execution_environment_max_concurrency` describes the maximum concurrency value used by the execution environment.

They have the same value  because the Rust runtime uses the configured concurrency limit directly as both the worker-pool size and the execution environment concurrency limit. Keeping both fields makes the event schema explicit and leaves room to represent different values if the runtime later introduces separate worker-pool sizing and execution-environment limits.

### Behavior

- Emitted once per concurrent runtime initialization.
- Emitted only when the runtime enters the concurrent path.
- Not emitted for sequential execution.
- Not emitted once per invocation.
- Uses the existing `tracing` infrastructure and does not add dependencies.
- Uses idiomatic Rust `snake_case` field names.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p lambda_runtime --features concurrency-tokio`
- 50 unit tests passed

Did integration tests deploying an LMI function

<img width="1406" height="379" alt="Screenshot 2026-09-06 at 12 26 33" src="https://github.com/user-attachments/assets/4593193c-0fe3-46e8-92a2-eeeb5a3135cc" />

- [x ] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
